### PR TITLE
<a> tag fix

### DIFF
--- a/btc-price-tooltip.php
+++ b/btc-price-tooltip.php
@@ -32,7 +32,7 @@ function add_tooltip_to_btc($the_content)
     for ($i = 0, $c = count($btc_in_text);$i < $c;$i++)
     {
         //echo $btc_in_text[$i];
-        $the_content = preg_replace('#' . $btc_in_text[$i] . '#iu', '<span class="tooltip" data-tooltip="' . $btcAnswerUsd . '/ ' . $btcAnswerEUR . '">' . $btc_in_text[$i] . '</span>', $the_content);
+        $the_content = preg_replace('#(?<!<a[^>]*>)' . $btc_in_text[$i] . '(?![^<]*</a>)#iu', '<span class="tooltip" data-tooltip="' . $btcAnswerUsd . '/ ' . $btcAnswerEUR . '">' . $btc_in_text[$i] . '</span>', $the_content);
     }
 
     return $the_content;


### PR DESCRIPTION
Make sure that the mentions of "Bitcoin" or "BTC" that you want to replace are not within an <a> tag

The lookahead `(?<!<a[^>]*>)` asserts that the match will not be preceded by an opening `<a>` tag, and the lookahead `(?![^<]*</a>)` asserts that the match will not be followed by a closing `</a>` tag. This will ensure that the replacement will only occur outside of <a> tags.